### PR TITLE
Drop possibly defective requirements for constexpr-ness

### DIFF
--- a/papers/optional_ref_wording.tex
+++ b/papers/optional_ref_wording.tex
@@ -311,10 +311,6 @@ Add a reference specialization for the std::optional template.
     \pnum
     \ensures
     \tcode{*this} does not refer to a value.
-
-    \pnum
-    \remarks
-    For every object type \tcode{T} these constructors are constexpr constructors\iref{dcl.constexpr}.
   \end{itemdescr}
 
   \indexlibraryctor{optional}%

--- a/papers/optional_ref_wording.tex
+++ b/papers/optional_ref_wording.tex
@@ -582,10 +582,6 @@ Add a reference specialization for the std::optional template.
     \pnum
     \returns
     \tcode{val}.
-
-    \pnum
-    \remarks
-    These functions are constexpr functions.
   \end{itemdescr}
 
   \indexlibrarymember{operator*}{optional}%
@@ -602,10 +598,6 @@ Add a reference specialization for the std::optional template.
     \pnum
     \returns
     \tcode{*val}.
-
-    \pnum
-    \remarks
-    These functions are constexpr functions.
   \end{itemdescr}
 
   \indexlibrarymember{operator bool}{optional}%
@@ -617,10 +609,6 @@ Add a reference specialization for the std::optional template.
     \pnum
     \returns
     \tcode{true} if and only if \tcode{*this} refers to a value.
-
-    \pnum
-    \remarks
-    This function is a constexpr function.
   \end{itemdescr}
 
   \indexlibrarymember{has_value}{optional}%
@@ -632,10 +620,6 @@ Add a reference specialization for the std::optional template.
     \pnum
     \returns
     \tcode{true} if and only if \tcode{*this} refers to a value.
-
-    \pnum
-    \remarks
-    This function is a constexpr function.
   \end{itemdescr}
 
   \indexlibrarymember{value}{optional}%


### PR DESCRIPTION
The additional requirements for constexpr-ness look redundant and possibly defective. We should stop copying them from the existing wording. See [LWG2829](https://cplusplus.github.io/LWG/issue2829) and [LWG2833](https://cplusplus.github.io/LWG/issue2833).