### PR TITLE
Fix rvalref

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ project(stl-concepts VERSION 0.0.0 LANGUAGES CXX)
 
 enable_testing()
 
-set(CMAKE_CXX_STANDARD 20)
-
 set(TARGETS_EXPORT_NAME ${CMAKE_PROJECT_NAME}Targets)
 
 add_subdirectory(extern)

--- a/etc/clang-17-toolchain.cmake
+++ b/etc/clang-17-toolchain.cmake
@@ -3,9 +3,10 @@ include_guard(GLOBAL)
 set(CMAKE_C_COMPILER clang-17)
 set(CMAKE_CXX_COMPILER clang++-17)
 
+set(CMAKE_CXX_STANDARD 20)
+
 set(CMAKE_CXX_FLAGS
-  "-std=gnu++23 \
-   -Wall -Wextra \
+   "-Wall -Wextra \
    -stdlib=libstdc++ "
 CACHE STRING "CXX_FLAGS" FORCE)
 

--- a/etc/gcc-14-toolchain.cmake
+++ b/etc/gcc-14-toolchain.cmake
@@ -3,13 +3,14 @@ include_guard(GLOBAL)
 set(CMAKE_C_COMPILER gcc-14)
 set(CMAKE_CXX_COMPILER g++-14)
 
+set(CMAKE_CXX_STANDARD 23)
+
 set(CMAKE_CXX_FLAGS
-  "-std=c++20 \
-   -Wall -Wextra "
+   "-Wall -Wextra "
 CACHE STRING "CXX_FLAGS" FORCE)
 
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3" CACHE STRING "C++ DEBUG Flags" FORCE)
 set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -g0 -DNDEBUG" CACHE STRING "C++ Release Flags" FORCE)
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG" CACHE STRING "C++ RelWithDebInfo Flags" FORCE)
 set(CMAKE_CXX_FLAGS_TSAN "-O3 -g -DNDEBUG -fsanitize=thread" CACHE STRING "C++ TSAN Flags" FORCE)
-set(CMAKE_CXX_FLAGS_ASAN "-O3 -g -DNDEBUG -fsanitize=address,undefined,leak" CACHE STRING "C++ ASAN Flags" FORCE)
+set(CMAKE_CXX_FLAGS_ASAN "-O3 -g -DNDEBUG -fsanitize=undefined" CACHE STRING "C++ ASAN Flags" FORCE)

--- a/etc/gcc-14-toolchain.cmake
+++ b/etc/gcc-14-toolchain.cmake
@@ -1,12 +1,11 @@
 include_guard(GLOBAL)
 
-set(CMAKE_C_COMPILER clang-17)
-set(CMAKE_CXX_COMPILER clang++-17)
+set(CMAKE_C_COMPILER gcc-14)
+set(CMAKE_CXX_COMPILER g++-14)
 
 set(CMAKE_CXX_FLAGS
-  "-std=gnu++23 \
-   -Wall -Wextra \
-   -stdlib=libstdc++ "
+  "-std=c++20 \
+   -Wall -Wextra "
 CACHE STRING "CXX_FLAGS" FORCE)
 
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3" CACHE STRING "C++ DEBUG Flags" FORCE)

--- a/etc/gcc-toolchain.cmake
+++ b/etc/gcc-toolchain.cmake
@@ -12,4 +12,4 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-inline -g3" CACHE STRING "C++ DEBUG Flags" F
 set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -g0 -DNDEBUG" CACHE STRING "C++ Release Flags" FORCE)
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG" CACHE STRING "C++ RelWithDebInfo Flags" FORCE)
 set(CMAKE_CXX_FLAGS_TSAN "-O3 -g -DNDEBUG -fsanitize=thread" CACHE STRING "C++ TSAN Flags" FORCE)
-set(CMAKE_CXX_FLAGS_ASAN "-O3 -g -DNDEBUG -fsanitize=address -fsanitize=undefined -fsanitize=leak" CACHE STRING "C++ ASAN Flags" FORCE)
+set(CMAKE_CXX_FLAGS_ASAN "-O3 -g -DNDEBUG -fsanitize=address,undefined,leak" CACHE STRING "C++ ASAN Flags" FORCE)

--- a/src/smd/optional/CMakeLists.txt
+++ b/src/smd/optional/CMakeLists.txt
@@ -37,6 +37,7 @@ target_sources(
   PRIVATE
   optional.t.cpp
   optional_ref.t.cpp
+  optional_monadic.t.cpp
 )
 
 target_link_libraries(optional_test optional)

--- a/src/smd/optional/CMakeLists.txt
+++ b/src/smd/optional/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(
   optional.t.cpp
   optional_ref.t.cpp
   optional_monadic.t.cpp
+  optional_ref_monadic.t.cpp
 )
 
 target_link_libraries(optional_test optional)

--- a/src/smd/optional/optional.h
+++ b/src/smd/optional/optional.h
@@ -1021,31 +1021,12 @@ class optional<T&> {
     // \rSec3[optional.observe]{Observers}
     constexpr T* operator->() const noexcept { return value_; }
 
-    constexpr T&  operator*() const& noexcept { return *value_; }
-    constexpr T&& operator*() const&& noexcept { return *value_; }
+    constexpr T&  operator*() const noexcept { return *value_; }
 
     constexpr explicit operator bool() const noexcept { return value_ != nullptr; }
     constexpr bool     has_value() const noexcept { return value_ != nullptr; }
 
-    constexpr T& value() const& {
-        if (has_value())
-            return *value_;
-        throw bad_optional_access();
-    }
-
-    constexpr T& value() & {
-        if (has_value())
-            return *value_;
-        throw bad_optional_access();
-    }
-
-    constexpr T&& value() && {
-        if (has_value())
-            return *value_;
-        throw bad_optional_access();
-    }
-
-    constexpr const T&& value() const&& {
+    constexpr T& value() const {
         if (has_value())
             return *value_;
         throw bad_optional_access();
@@ -1100,8 +1081,8 @@ class optional<T&> {
     }
 
     template <class F>
-    constexpr auto transform(F&& f) & {
-        return detail::optional_map_impl(*this, std::forward<F>(f));
+    constexpr auto transform(F&& f) const -> optional<std::invoke_result_t<F, T&>> {
+      return detail::optional_map_impl(*this, std::forward<F>(f));
     }
 
     template <class F>

--- a/src/smd/optional/optional_monadic.t.cpp
+++ b/src/smd/optional/optional_monadic.t.cpp
@@ -1,0 +1,315 @@
+#include <smd/optional/optional.h>
+
+#include <smd/optional/optional.h>
+
+#include <gtest/gtest.h>
+
+constexpr int get_int(int) { return 42; }
+constexpr smd::optional::optional<int> get_opt_int(int) { return 42; }
+
+
+TEST(OptionalMonadicTest, Transform) {
+  // lhs is empty
+    smd::optional::optional<int> o1;
+    auto o1r = o1.transform([](int i) { return i + 2; });
+    static_assert((std::is_same<decltype(o1r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(!o1r);
+
+    // lhs has value
+    smd::optional::optional<int> o2 = 40;
+    auto o2r = o2.transform([](int i) { return i + 2; });
+    static_assert((std::is_same<decltype(o2r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(o2r.value() == 42);
+
+    struct rval_call_transform {
+      double operator()(int) && { return 42.0; };
+    };
+
+    // ensure that function object is forwarded
+    smd::optional::optional<int> o3 = 42;
+    auto o3r = o3.transform(rval_call_transform{});
+    static_assert((std::is_same<decltype(o3r), smd::optional::optional<double>>::value));
+    EXPECT_TRUE(o3r.value() == 42);
+
+    // ensure that lhs is forwarded
+    smd::optional::optional<int> o4 = 40;
+    auto o4r = std::move(o4).transform([](int &&i) { return i + 2; });
+    static_assert((std::is_same<decltype(o4r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(o4r.value() == 42);
+
+    // ensure that lhs is const-propagated
+    const smd::optional::optional<int> o5 = 40;
+    auto o5r = o5.transform([](const int &i) { return i + 2; });
+    static_assert((std::is_same<decltype(o5r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(o5r.value() == 42);
+
+
+    // test each overload in turn
+    smd::optional::optional<int> o8 = 42;
+    auto o8r = o8.transform([](int) { return 42; });
+    EXPECT_TRUE(*o8r == 42);
+
+    smd::optional::optional<int> o12 = 42;
+    auto o12r = std::move(o12).transform([](int) { return 42; });
+    EXPECT_TRUE(*o12r == 42);
+
+    const smd::optional::optional<int> o16 = 42;
+    auto o16r = o16.transform([](int) { return 42; });
+    EXPECT_TRUE(*o16r == 42);
+
+    const smd::optional::optional<int> o20 = 42;
+    auto o20r = std::move(o20).transform([](int) { return 42; });
+    EXPECT_TRUE(*o20r == 42);
+
+    smd::optional::optional<int> o24 = smd::optional::nullopt;
+    auto o24r = o24.transform([](int) { return 42; });
+    EXPECT_TRUE(!o24r);
+
+    smd::optional::optional<int> o28 = smd::optional::nullopt;
+    auto o28r = std::move(o28).transform([](int) { return 42; });
+    EXPECT_TRUE(!o28r);
+
+    const smd::optional::optional<int> o32 = smd::optional::nullopt;
+    auto o32r = o32.transform([](int) { return 42; });
+    EXPECT_TRUE(!o32r);
+
+    const smd::optional::optional<int> o36 = smd::optional::nullopt;
+    auto o36r = std::move(o36).transform([](int) { return 42; });
+    EXPECT_TRUE(!o36r);
+
+    // callable which returns a reference
+    smd::optional::optional<int> o38 = 42;
+    auto o38r = o38.transform([](int &i) -> const int & { return i; });
+    EXPECT_TRUE(o38r);
+    EXPECT_TRUE(*o38r == 42);
+
+  }
+
+TEST(OptionalMonadicTest, TransformConstexpr) {
+
+    // test each overload in turn
+    constexpr smd::optional::optional<int> o16 = 42;
+    constexpr auto o16r = o16.transform(get_int);
+    static_assert(*o16r == 42);
+
+    constexpr smd::optional::optional<int> o20 = 42;
+    constexpr auto o20r = std::move(o20).transform(get_int);
+    static_assert(*o20r == 42);
+
+    constexpr smd::optional::optional<int> o32 = smd::optional::nullopt;
+    constexpr auto o32r = o32.transform(get_int);
+    static_assert(!o32r);
+    constexpr smd::optional::optional<int> o36 = smd::optional::nullopt;
+    constexpr auto o36r = std::move(o36).transform(get_int);
+    static_assert(!o36r);
+  }
+
+TEST(OptionalMonadicTest, Transform2) {
+  // lhs is empty
+    smd::optional::optional<int> o1;
+    auto o1r = o1.transform([](int i) { return i + 2; });
+    static_assert((std::is_same<decltype(o1r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(!o1r);
+
+    // lhs has value
+    smd::optional::optional<int> o2 = 40;
+    auto o2r = o2.transform([](int i) { return i + 2; });
+    static_assert((std::is_same<decltype(o2r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(o2r.value() == 42);
+
+    struct rval_call_transform {
+      double operator()(int) && { return 42.0; };
+    };
+
+    // ensure that function object is forwarded
+    smd::optional::optional<int> o3 = 42;
+    auto o3r = o3.transform(rval_call_transform{});
+    static_assert((std::is_same<decltype(o3r), smd::optional::optional<double>>::value));
+    EXPECT_TRUE(o3r.value() == 42);
+
+    // ensure that lhs is forwarded
+    smd::optional::optional<int> o4 = 40;
+    auto o4r = std::move(o4).transform([](int&& i) { return i + 2; });
+    static_assert((std::is_same<decltype(o4r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(o4r.value() == 42);
+
+    // ensure that lhs is const-propagated
+    const smd::optional::optional<int> o5 = 40;
+    auto o5r = o5.transform([](const int& i) { return i + 2; });
+    static_assert((std::is_same<decltype(o5r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(o5r.value() == 42);
+
+    // test each overload in turn
+    smd::optional::optional<int> o8 = 42;
+    auto o8r = o8.transform([](int) { return 42; });
+    EXPECT_TRUE(*o8r == 42);
+
+    smd::optional::optional<int> o12 = 42;
+    auto o12r = std::move(o12).transform([](int) { return 42; });
+    EXPECT_TRUE(*o12r == 42);
+
+    const smd::optional::optional<int> o16 = 42;
+    auto o16r = o16.transform([](int) { return 42; });
+    EXPECT_TRUE(*o16r == 42);
+
+    const smd::optional::optional<int> o20 = 42;
+    auto o20r = std::move(o20).transform([](int) { return 42; });
+    EXPECT_TRUE(*o20r == 42);
+
+    smd::optional::optional<int> o24 = smd::optional::nullopt;
+    auto o24r = o24.transform([](int) { return 42; });
+    EXPECT_TRUE(!o24r);
+
+    smd::optional::optional<int> o28 = smd::optional::nullopt;
+    auto o28r = std::move(o28).transform([](int) { return 42; });
+    EXPECT_TRUE(!o28r);
+
+    const smd::optional::optional<int> o32 = smd::optional::nullopt;
+    auto o32r = o32.transform([](int) { return 42; });
+    EXPECT_TRUE(!o32r);
+
+    const smd::optional::optional<int> o36 = smd::optional::nullopt;
+    auto o36r = std::move(o36).transform([](int) { return 42; });
+    EXPECT_TRUE(!o36r);
+  }
+
+TEST(OptionalMonadicTest, TransformConstxpr)
+ {
+    // test each overload in turn
+    constexpr smd::optional::optional<int> o16 = 42;
+    constexpr auto o16r = o16.transform(get_int);
+    static_assert(*o16r == 42);
+
+    constexpr smd::optional::optional<int> o20 = 42;
+    constexpr auto o20r = std::move(o20).transform(get_int);
+    static_assert(*o20r == 42);
+
+    constexpr smd::optional::optional<int> o32 = smd::optional::nullopt;
+    constexpr auto o32r = o32.transform(get_int);
+    static_assert(!o32r);
+    constexpr smd::optional::optional<int> o36 = smd::optional::nullopt;
+    constexpr auto o36r = std::move(o36).transform(get_int);
+    static_assert(!o36r);
+  }
+
+TEST(OptionalMonadicTest, and_then)
+ {
+    // lhs is empty
+    smd::optional::optional<int> o1;
+    auto o1r = o1.and_then([](int) { return smd::optional::optional<float>{42}; });
+    static_assert((std::is_same<decltype(o1r), smd::optional::optional<float>>::value));
+    EXPECT_TRUE(!o1r);
+
+    // lhs has value
+    smd::optional::optional<int> o2 = 12;
+    auto o2r = o2.and_then([](int) { return smd::optional::optional<float>{42}; });
+    static_assert((std::is_same<decltype(o2r), smd::optional::optional<float>>::value));
+    EXPECT_TRUE(o2r.value() == 42.f);
+
+    // lhs is empty, rhs returns empty
+    smd::optional::optional<int> o3;
+    auto o3r = o3.and_then([](int) { return smd::optional::optional<float>{}; });
+    static_assert((std::is_same<decltype(o3r), smd::optional::optional<float>>::value));
+    EXPECT_TRUE(!o3r);
+
+    // rhs returns empty
+    smd::optional::optional<int> o4 = 12;
+    auto o4r = o4.and_then([](int) { return smd::optional::optional<float>{}; });
+    static_assert((std::is_same<decltype(o4r), smd::optional::optional<float>>::value));
+    EXPECT_TRUE(!o4r);
+
+    struct rval_call_and_then {
+      smd::optional::optional<double> operator()(int) && {
+        return smd::optional::optional<double>(42.0);
+      };
+    };
+
+    // ensure that function object is forwarded
+    smd::optional::optional<int> o5 = 42;
+    auto o5r = o5.and_then(rval_call_and_then{});
+    static_assert((std::is_same<decltype(o5r), smd::optional::optional<double>>::value));
+    EXPECT_TRUE(o5r.value() == 42);
+
+    // ensure that lhs is forwarded
+    smd::optional::optional<int> o6 = 42;
+    auto o6r =
+        std::move(o6).and_then([](int &&i) { return smd::optional::optional<double>(i); });
+    static_assert((std::is_same<decltype(o6r), smd::optional::optional<double>>::value));
+    EXPECT_TRUE(o6r.value() == 42);
+
+    // ensure that function object is const-propagated
+    const smd::optional::optional<int> o7 = 42;
+    auto o7r =
+        o7.and_then([](const int &i) { return smd::optional::optional<double>(i); });
+    static_assert((std::is_same<decltype(o7r), smd::optional::optional<double>>::value));
+    EXPECT_TRUE(o7r.value() == 42);
+
+    // test each overload in turn
+    smd::optional::optional<int> o8 = 42;
+    auto o8r = o8.and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(*o8r == 42);
+
+    smd::optional::optional<int> o9 = 42;
+    auto o9r =
+        std::move(o9).and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(*o9r == 42);
+
+    const smd::optional::optional<int> o10 = 42;
+    auto o10r = o10.and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(*o10r == 42);
+
+    const smd::optional::optional<int> o11 = 42;
+    auto o11r =
+        std::move(o11).and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(*o11r == 42);
+
+    smd::optional::optional<int> o16 = smd::optional::nullopt;
+    auto o16r = o16.and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(!o16r);
+
+    smd::optional::optional<int> o17 = smd::optional::nullopt;
+    auto o17r =
+        std::move(o17).and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(!o17r);
+
+    const smd::optional::optional<int> o18 = smd::optional::nullopt;
+    auto o18r = o18.and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(!o18r);
+
+    const smd::optional::optional<int> o19 = smd::optional::nullopt;
+    auto o19r = std::move(o19).and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(!o19r);
+
+    int i = 3;
+    smd::optional::optional<int&> o20{i};
+    std::move(o20).and_then([](int& r){return smd::optional::optional<int&>{++r};});
+    EXPECT_TRUE(o20);
+    EXPECT_TRUE(i == 4);
+  }
+
+TEST(OptionalMonadicTest, Constexpr_and_then)
+{
+    constexpr smd::optional::optional<int> o10 = 42;
+    constexpr auto o10r = o10.and_then(get_opt_int);
+    EXPECT_TRUE(*o10r == 42);
+
+    constexpr smd::optional::optional<int> o11 = 42;
+    constexpr auto o11r = std::move(o11).and_then(get_opt_int);
+    EXPECT_TRUE(*o11r == 42);
+
+    constexpr smd::optional::optional<int> o18 = smd::optional::nullopt;
+    constexpr auto o18r = o18.and_then(get_opt_int);
+    EXPECT_TRUE(!o18r);
+
+    constexpr smd::optional::optional<int> o19 = smd::optional::nullopt;
+    constexpr auto o19r = std::move(o19).and_then(get_opt_int);
+    EXPECT_TRUE(!o19r);
+  }
+
+TEST(OptionalMonadicTest, or_else){
+    smd::optional::optional<int> o1 = 42;
+    EXPECT_TRUE(*(o1.or_else([] { return smd::optional::make_optional(13); })) == 42);
+
+    smd::optional::optional<int> o2;
+    EXPECT_EQ(*(o2.or_else([] { return smd::optional::make_optional(13); })),  13);
+  }

--- a/src/smd/optional/optional_ref.t.cpp
+++ b/src/smd/optional/optional_ref.t.cpp
@@ -436,12 +436,70 @@ TEST(OptionalRefTest, Observers) {
     auto success = std::is_same<decltype(o1.value()), int&>::value;
     static_assert(std::is_same<decltype(o1.value()), int&>::value);
     EXPECT_TRUE(success);
+    success = std::is_same<decltype(o2.value()), int&>::value;
+    static_assert(std::is_same<decltype(o2.value()), int&>::value);
+    EXPECT_TRUE(success);
     success = std::is_same<decltype(o3.value()), int&>::value;
     static_assert(std::is_same<decltype(o3.value()), int&>::value);
     EXPECT_TRUE(success);
-    success = std::is_same<decltype(std::move(o1).value()), int&&>::value;
-    static_assert(std::is_same<decltype(std::move(o1).value()), int&&>::value);
+    success = std::is_same<decltype(std::move(o1).value()), int&>::value;
+    static_assert(std::is_same<decltype(std::move(o1).value()), int&>::value);
     EXPECT_TRUE(success);
+
+    success = std::is_same<decltype(*o1), int&>::value;
+    static_assert(std::is_same<decltype(*o1), int&>::value);
+    EXPECT_TRUE(success);
+    success = std::is_same<decltype(*o2), int&>::value;
+    static_assert(std::is_same<decltype(*o2), int&>::value);
+    EXPECT_TRUE(success);
+    success = std::is_same<decltype(*o3), int&>::value;
+    static_assert(std::is_same<decltype(*o3), int&>::value);
+    EXPECT_TRUE(success);
+    success = std::is_same<decltype(*std::move(o1)), int&>::value;
+    static_assert(std::is_same<decltype(*std::move(o1)), int&>::value);
+    EXPECT_TRUE(success);
+
+    success = std::is_same<decltype(o1.operator->()), int*>::value;
+    static_assert(std::is_same<decltype(o1.operator->()), int*>::value);
+    EXPECT_TRUE(success);
+    success = std::is_same<decltype(o2.operator->()), int*>::value;
+    static_assert(std::is_same<decltype(o2.operator->()), int*>::value);
+    EXPECT_TRUE(success);
+    success = std::is_same<decltype(o3.operator->()), int*>::value;
+    static_assert(std::is_same<decltype(o3.operator->()), int*>::value);
+    EXPECT_TRUE(success);
+    success = std::is_same<decltype(std::move(o1).operator->()), int*>::value;
+    static_assert(std::is_same<decltype(std::move(o1).operator->()), int*>::value);
+    EXPECT_TRUE(success);
+
+    struct int_box {int i_;};
+    int_box i1{3};
+    smd::optional::optional<int_box&>       ob1  = i1;
+    smd::optional::optional<int_box&>       ob2;
+    const smd::optional::optional<int_box&> ob3 = i1;
+    success = std::is_same<decltype(ob1->i_), int>::value;
+    static_assert(std::is_same<decltype(ob1->i_), int>::value);
+    EXPECT_TRUE(success);
+    success = std::is_same<decltype(ob2->i_), int>::value;
+    static_assert(std::is_same<decltype(ob2->i_), int>::value);
+    EXPECT_TRUE(success);
+    success = std::is_same<decltype(ob3->i_), int>::value;
+    static_assert(std::is_same<decltype(ob3->i_), int>::value);
+    EXPECT_TRUE(success);
+    success = std::is_same<decltype(std::move(ob1)->i_), int>::value;
+    static_assert(std::is_same<decltype(std::move(ob1)->i_), int>::value);
+    EXPECT_TRUE(success);
+
+}
+
+TEST(OptionalRefTest, MoveCheck) {
+    int x = 0;
+    int& y =  std::move(smd::optional::optional<int&>(x)).value();
+    EXPECT_EQ(&y, &x);
+
+    int& z =  *std::move(smd::optional::optional<int&>(x));
+    EXPECT_EQ(&z, &x);
+
 }
 
 TEST(OptionalRefTest, SwapValue) {

--- a/src/smd/optional/optional_ref_monadic.t.cpp
+++ b/src/smd/optional/optional_ref_monadic.t.cpp
@@ -1,0 +1,320 @@
+#include <smd/optional/optional.h>
+
+#include <smd/optional/optional.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+inline constexpr int                          constexpr_fortytwo = 42;
+constexpr int                                 get_int(int) { return constexpr_fortytwo; }
+constexpr smd::optional::optional<const int&> get_opt_int(int) { return constexpr_fortytwo; }
+} // namespace
+
+TEST(OptionalRefMonadicTest, Transform) {
+    // lhs is empty
+    smd::optional::optional<int&> o1;
+    auto                          o1r = o1.transform([](int i) { return i + 2; });
+    static_assert((std::is_same<decltype(o1r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(!o1r);
+
+    // lhs has value
+    int                           forty = 40;
+    smd::optional::optional<int&> o2    = forty;
+    auto                          o2r   = o2.transform([](int i) { return i + 2; });
+    static_assert((std::is_same<decltype(o2r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(o2r.value() == 42);
+
+    struct rval_call_transform {
+        double operator()(int) && { return 42.0; };
+    };
+
+    // ensure that function object is forwarded
+    int                           fortytwo = 42;
+    smd::optional::optional<int&> o3       = fortytwo;
+    auto                          o3r      = o3.transform(rval_call_transform{});
+    static_assert((std::is_same<decltype(o3r), smd::optional::optional<double>>::value));
+    EXPECT_TRUE(o3r.value() == 42);
+
+    // // ensure that lhs is forwarded
+    // forty = 40;
+    // smd::optional::optional<int&> o4 = forty;
+    // auto o4r = std::move(o4).transform([](int &&i) { return i + 2; });
+    // static_assert((std::is_same<decltype(o4r), smd::optional::optional<int&>>::value));
+    // EXPECT_TRUE(o4r.value() == 42);
+
+    // ensure that lhs is const-propagated
+    forty                                   = 40;
+    const smd::optional::optional<int&> o5  = forty;
+    auto                                o5r = o5.transform([](const int& i) { return i + 2; });
+    static_assert((std::is_same<decltype(o5r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(o5r.value() == 42);
+
+    // test each overload in turn
+    fortytwo                          = 42;
+    smd::optional::optional<int&> o8  = fortytwo;
+    auto                          o8r = o8.transform([](int) { return 42; });
+    EXPECT_TRUE(*o8r == 42);
+
+    smd::optional::optional<int&> o12  = fortytwo;
+    auto                          o12r = std::move(o12).transform([](int) { return 42; });
+    EXPECT_TRUE(*o12r == 42);
+
+    const smd::optional::optional<int&> o16  = fortytwo;
+    auto                                o16r = o16.transform([](int) { return 42; });
+    EXPECT_TRUE(*o16r == 42);
+
+    const smd::optional::optional<int&> o20  = fortytwo;
+    auto                                o20r = std::move(o20).transform([](int) { return 42; });
+    EXPECT_TRUE(*o20r == 42);
+
+    smd::optional::optional<int&> o24  = smd::optional::nullopt;
+    auto                          o24r = o24.transform([](int) { return 42; });
+    EXPECT_TRUE(!o24r);
+
+    smd::optional::optional<int&> o28  = smd::optional::nullopt;
+    auto                          o28r = std::move(o28).transform([](int) { return 42; });
+    EXPECT_TRUE(!o28r);
+
+    const smd::optional::optional<int&> o32  = smd::optional::nullopt;
+    auto                                o32r = o32.transform([](int) { return 42; });
+    EXPECT_TRUE(!o32r);
+
+    const smd::optional::optional<int&> o36  = smd::optional::nullopt;
+    auto                                o36r = std::move(o36).transform([](int) { return 42; });
+    EXPECT_TRUE(!o36r);
+
+    // callable which returns a reference
+    smd::optional::optional<int&> o38  = fortytwo;
+    auto                          o38r = o38.transform([](int& i) -> const int& { return i; });
+    EXPECT_TRUE(o38r);
+    EXPECT_TRUE(*o38r == 42);
+}
+
+TEST(OptionalRefMonadicTest, TransformConstexpr) {
+
+    // test each overload in turn
+    constexpr smd::optional::optional<const int&> o16  = constexpr_fortytwo;
+    constexpr auto                                o16r = o16.transform(get_int);
+    static_assert(*o16r == 42);
+
+    constexpr smd::optional::optional<const int&> o20  = constexpr_fortytwo;
+    constexpr auto                                o20r = std::move(o20).transform(get_int);
+    static_assert(*o20r == 42);
+
+    constexpr smd::optional::optional<int&> o32  = smd::optional::nullopt;
+    constexpr auto                          o32r = o32.transform(get_int);
+    static_assert(!o32r);
+    constexpr smd::optional::optional<int&> o36  = smd::optional::nullopt;
+    constexpr auto                          o36r = std::move(o36).transform(get_int);
+    static_assert(!o36r);
+}
+
+TEST(OptionalRefMonadicTest, Transform2) {
+    // lhs is empty
+    smd::optional::optional<int&> o1;
+    auto                          o1r = o1.transform([](int i) { return i + 2; });
+    static_assert((std::is_same<decltype(o1r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(!o1r);
+
+    // lhs has value
+    int                           forty = 40;
+    smd::optional::optional<int&> o2    = forty;
+    auto                          o2r   = o2.transform([](int i) { return i + 2; });
+    static_assert((std::is_same<decltype(o2r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(o2r.value() == 42);
+
+    struct rval_call_transform {
+        double operator()(int) && { return 42.0; };
+    };
+
+    // ensure that function object is forwarded
+    int                           fortytwo = 42;
+    smd::optional::optional<int&> o3       = fortytwo;
+    auto                          o3r      = o3.transform(rval_call_transform{});
+    static_assert((std::is_same<decltype(o3r), smd::optional::optional<double>>::value));
+    EXPECT_TRUE(o3r.value() == 42);
+
+    // // ensure that lhs is forwarded
+    // int forty = 40;
+    // smd::optional::optional<int&> o4 = forty;
+    // auto o4r = std::move(o4).transform([](int&& i) { return i + 2; });
+    // static_assert((std::is_same<decltype(o4r), smd::optional::optional<int&>>::value));
+    // EXPECT_TRUE(o4r.value() == 42);
+
+    // ensure that lhs is const-propagated
+    forty                                   = 40;
+    const smd::optional::optional<int&> o5  = forty;
+    auto                                o5r = o5.transform([](const int& i) { return i + 2; });
+    static_assert((std::is_same<decltype(o5r), smd::optional::optional<int>>::value));
+    EXPECT_TRUE(o5r.value() == 42);
+
+    // test each overload in turn
+    fortytwo                          = 42;
+    smd::optional::optional<int&> o8  = fortytwo;
+    auto                          o8r = o8.transform([](int) { return 42; });
+    EXPECT_TRUE(*o8r == 42);
+
+    smd::optional::optional<int&> o12  = fortytwo;
+    auto                          o12r = std::move(o12).transform([](int) { return 42; });
+    EXPECT_TRUE(*o12r == 42);
+
+    const smd::optional::optional<int&> o16  = fortytwo;
+    auto                                o16r = o16.transform([](int) { return 42; });
+    EXPECT_TRUE(*o16r == 42);
+
+    const smd::optional::optional<int&> o20  = fortytwo;
+    auto                                o20r = std::move(o20).transform([](int) { return 42; });
+    EXPECT_TRUE(*o20r == 42);
+
+    smd::optional::optional<int&> o24  = smd::optional::nullopt;
+    auto                          o24r = o24.transform([](int) { return 42; });
+    EXPECT_TRUE(!o24r);
+
+    smd::optional::optional<int&> o28  = smd::optional::nullopt;
+    auto                          o28r = std::move(o28).transform([](int) { return 42; });
+    EXPECT_TRUE(!o28r);
+
+    const smd::optional::optional<int&> o32  = smd::optional::nullopt;
+    auto                                o32r = o32.transform([](int) { return 42; });
+    EXPECT_TRUE(!o32r);
+
+    const smd::optional::optional<int&> o36  = smd::optional::nullopt;
+    auto                                o36r = std::move(o36).transform([](int) { return 42; });
+    EXPECT_TRUE(!o36r);
+}
+
+TEST(OptionalRefMonadicTest, TransformConstxpr) {
+    // test each overload in turn
+    constexpr smd::optional::optional<const int&> o16  = constexpr_fortytwo;
+    constexpr auto                                o16r = o16.transform(get_int);
+    static_assert(*o16r == 42);
+
+    constexpr smd::optional::optional<const int&> o20  = constexpr_fortytwo;
+    constexpr auto                                o20r = std::move(o20).transform(get_int);
+    static_assert(*o20r == 42);
+
+    constexpr smd::optional::optional<const int&> o32  = smd::optional::nullopt;
+    constexpr auto                                o32r = o32.transform(get_int);
+    static_assert(!o32r);
+    constexpr smd::optional::optional<int&> o36  = smd::optional::nullopt;
+    constexpr auto                          o36r = std::move(o36).transform(get_int);
+    static_assert(!o36r);
+}
+
+TEST(OptionalRefMonadicTest, and_then) {
+    // lhs is empty
+    smd::optional::optional<int&> o1;
+    auto                          o1r = o1.and_then([](int) { return smd::optional::optional<float>{42}; });
+    static_assert((std::is_same<decltype(o1r), smd::optional::optional<float>>::value));
+    EXPECT_TRUE(!o1r);
+
+    // lhs has value
+    int                           twelve = 12;
+    smd::optional::optional<int&> o2     = twelve;
+    auto                          o2r    = o2.and_then([](int) { return smd::optional::optional<float>{42}; });
+    static_assert((std::is_same<decltype(o2r), smd::optional::optional<float>>::value));
+    EXPECT_TRUE(o2r.value() == 42.f);
+
+    // lhs is empty, rhs returns empty
+    smd::optional::optional<int&> o3;
+    auto                          o3r = o3.and_then([](int) { return smd::optional::optional<float>{}; });
+    static_assert((std::is_same<decltype(o3r), smd::optional::optional<float>>::value));
+    EXPECT_TRUE(!o3r);
+
+    // rhs returns empty
+    smd::optional::optional<int&> o4  = twelve;
+    auto                          o4r = o4.and_then([](int) { return smd::optional::optional<float>{}; });
+    static_assert((std::is_same<decltype(o4r), smd::optional::optional<float>>::value));
+    EXPECT_TRUE(!o4r);
+
+    struct rval_call_and_then {
+        smd::optional::optional<double> operator()(int) && { return smd::optional::optional<double>(42.0); };
+    };
+
+    // ensure that function object is forwarded
+    int                           fortytwo = 42;
+    smd::optional::optional<int&> o5       = fortytwo;
+    auto                          o5r      = o5.and_then(rval_call_and_then{});
+    static_assert((std::is_same<decltype(o5r), smd::optional::optional<double>>::value));
+    EXPECT_TRUE(o5r.value() == 42);
+
+    // // ensure that lhs is forwarded
+    // smd::optional::optional<int&> o6 = fortytwo;
+    // auto o6r =
+    //     std::move(o6).and_then([](int &&i) { return smd::optional::optional<double>(i); });
+    // static_assert((std::is_same<decltype(o6r), smd::optional::optional<double>>::value));
+    // EXPECT_TRUE(o6r.value() == 42);
+
+    // ensure that function object is const-propagated
+    const smd::optional::optional<int&> o7 = fortytwo;
+    auto o7r = o7.and_then([](const int& i) { return smd::optional::optional<double>(i); });
+    static_assert((std::is_same<decltype(o7r), smd::optional::optional<double>>::value));
+    EXPECT_TRUE(o7r.value() == 42);
+
+    // test each overload in turn
+    smd::optional::optional<int&> o8  = fortytwo;
+    auto                          o8r = o8.and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(*o8r == 42);
+
+    smd::optional::optional<int&> o9  = fortytwo;
+    auto                          o9r = std::move(o9).and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(*o9r == 42);
+
+    const smd::optional::optional<int&> o10  = fortytwo;
+    auto                                o10r = o10.and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(*o10r == 42);
+
+    const smd::optional::optional<int&> o11 = fortytwo;
+    auto o11r = std::move(o11).and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(*o11r == 42);
+
+    smd::optional::optional<int&> o16  = smd::optional::nullopt;
+    auto                          o16r = o16.and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(!o16r);
+
+    smd::optional::optional<int&> o17  = smd::optional::nullopt;
+    auto                          o17r = std::move(o17).and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(!o17r);
+
+    const smd::optional::optional<int&> o18  = smd::optional::nullopt;
+    auto                                o18r = o18.and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(!o18r);
+
+    const smd::optional::optional<int&> o19 = smd::optional::nullopt;
+    auto o19r = std::move(o19).and_then([](int) { return smd::optional::make_optional(42); });
+    EXPECT_TRUE(!o19r);
+
+    int                           i = 3;
+    smd::optional::optional<int&> o20{i};
+    std::move(o20).and_then([](int& r) { return smd::optional::optional<int&>{++r}; });
+    EXPECT_TRUE(o20);
+    EXPECT_TRUE(i == 4);
+}
+
+TEST(OptionalRefMonadicTest, Constexpr_and_then) {
+    constexpr smd::optional::optional<const int&> o10  = constexpr_fortytwo;
+    constexpr auto                                o10r = o10.and_then(get_opt_int);
+    EXPECT_TRUE(*o10r == 42);
+
+    constexpr smd::optional::optional<const int&> o11  = constexpr_fortytwo;
+    constexpr auto                                o11r = std::move(o11).and_then(get_opt_int);
+    EXPECT_TRUE(*o11r == 42);
+
+    constexpr smd::optional::optional<int&> o18  = smd::optional::nullopt;
+    constexpr auto                          o18r = o18.and_then(get_opt_int);
+    EXPECT_TRUE(!o18r);
+
+    constexpr smd::optional::optional<int&> o19  = smd::optional::nullopt;
+    constexpr auto                          o19r = std::move(o19).and_then(get_opt_int);
+    EXPECT_TRUE(!o19r);
+}
+
+TEST(OptionalRefMonadicTest, or_else) {
+    int                           fortytwo = 42;
+    int                           thirteen = 13;
+    smd::optional::optional<int&> o1       = fortytwo;
+    EXPECT_TRUE(*(o1.or_else([&] { return smd::optional::optional<int&>(thirteen); })) == 42);
+
+    smd::optional::optional<int&> o2;
+    EXPECT_EQ(*(o2.or_else([&] { return smd::optional::optional<int&>(thirteen); })), 13);
+}


### PR DESCRIPTION
Move for the referred to object is independent of the value category of the optional. It shouldn't happen by default to avoid surprising steals. 
