### PR TITLE
Because make_optional exists it must not change

### DIFF
--- a/src/smd/optional/optional.h
+++ b/src/smd/optional/optional.h
@@ -216,17 +216,9 @@ using is_optional = is_optional_impl<std::decay_t<T>>;
 template <typename T>
 constexpr optional<std::decay_t<T>>
 make_optional(T&& __t) noexcept(std::is_nothrow_constructible_v<optional<std::decay_t<T>>, T>)
-    requires std::is_constructible_v<std::decay_t<T>, T> && (!std::is_reference_v<T>)
+    requires std::is_constructible_v<std::decay_t<T>, T>
 {
     return optional<std::decay_t<T>>{std::forward<T>(__t)};
-}
-
-template <typename T>
-constexpr optional<std::decay_t<T>&>
-make_optional(T&& __t) noexcept(std::is_nothrow_constructible_v<optional<std::decay_t<T>>, T>)
-    requires std::is_constructible_v<std::decay_t<T>, T> && (std::is_reference_v<T>)
-{
-    return optional<std::decay_t<T>&>{std::forward<T>(__t)};
 }
 
 template <typename T, typename... _Args>

--- a/src/smd/optional/optional.t.cpp
+++ b/src/smd/optional/optional.t.cpp
@@ -333,10 +333,10 @@ TEST(OptionalTest, MakeOptional) {
 
     auto i  = 42;
     auto o6 = smd::optional::make_optional<int&>(i);
-    static_assert(std::is_same<decltype(o6), smd::optional::optional<int&>>::value);
+    static_assert(std::is_same<decltype(o6), smd::optional::optional<int>>::value);
 
     EXPECT_TRUE(
-        (std::is_same<decltype(o6), smd::optional::optional<int&>>::value));
+        (std::is_same<decltype(o6), smd::optional::optional<int>>::value));
     EXPECT_TRUE(o6);
     EXPECT_TRUE(*o6 == 42);
 }

--- a/src/smd/optional/optional_ref.t.cpp
+++ b/src/smd/optional/optional_ref.t.cpp
@@ -369,7 +369,7 @@ TEST(OptionalRefTest, MakeOptional) {
     auto o1 = smd::optional::make_optional<int&>(var);
     auto o2 = smd::optional::optional<int&>(var);
 
-    constexpr bool is_same = std::is_same<decltype(o1), smd::optional::optional<int&>>::value;
+    constexpr bool is_same = std::is_same<decltype(o1), smd::optional::optional<int>>::value;
     EXPECT_TRUE(is_same);
     EXPECT_TRUE(o1 == o2);
 
@@ -396,9 +396,9 @@ TEST(OptionalRefTest, MakeOptional) {
 
     auto i  = 42;
     auto o6 = smd::optional::make_optional<int&>(i);
-    static_assert(std::is_same<decltype(o6), smd::optional::optional<int&>>::value);
+    static_assert(std::is_same_v<decltype(o6), smd::optional::optional<int>>);
 
-    EXPECT_TRUE((std::is_same<decltype(o6), smd::optional::optional<int&>>::value));
+    EXPECT_TRUE((std::is_same_v<decltype(o6), smd::optional::optional<int>>));
     EXPECT_TRUE(o6);
     EXPECT_TRUE(*o6 == 42);
 }


### PR DESCRIPTION
make_optional produces a T when T& is deduced, and this behavior must not change. Although it's unsatisfying.